### PR TITLE
Missing return in stringGenerator()

### DIFF
--- a/src/tool.c
+++ b/src/tool.c
@@ -101,4 +101,5 @@ char	*stringGenerator(int i)
 		i--;
 		s[i] = rand();
 	}
+	return (s);
 }


### PR DESCRIPTION
The stringGenerator function was missing its return. It was preventing the random_s function from functioning correctly.